### PR TITLE
Add cache busting and fix slide in animations

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,8 @@ var ga = require('gulp-ga');
 var pug = require('gulp-pug');
 var ghPages = require('gulp-gh-pages');
 
+var cachebust = require('./scripts/gulp-cache-bust');
+
 const pastProjectsEntries = [
   {
     id: 'engineer-apart',
@@ -113,14 +115,19 @@ gulp.task('copy-img', function () {
 
 // Convert Pug template to html
 gulp.task('pug', function buildHTML() {
-  return gulp.src('./html/*.pug')
+  var gulpSrc = gulp.src('./html/index.pug')
     .pipe(pug({
       pretty: process.env.NODE_ENV === 'development',
       locals: {
         carouselEntries: pastProjectsEntries,
       }
-    }))
-    .pipe(gulp.dest('./static/'));
+    }));
+
+    if (process.env.NODE_ENV === 'production') {
+      gulpSrc = gulpSrc.pipe(cachebust({ type: 'timestamp' }));
+    }
+
+    return gulpSrc.pipe(gulp.dest('./static/'));
 });
 
 // Google Analytics

--- a/js/engineer-apart.js
+++ b/js/engineer-apart.js
@@ -9,7 +9,11 @@
         var H = $(this).height(),
           r = el.getBoundingClientRect(), t = r.top, b = r.bottom;
         return cb.call(el, Math.max(0, t > 0 ? H - t : (b < H ? b : H)));
-      } visPx();
+      }
+      // the "scroll restore" fires AFTER document ready - so if you are already scrolled,
+      // the initial call to visPx() won't have any effect unless we do it later.
+      // Scroll restore has no events.
+      setTimeout(visPx, 500);
       $(win).on("resize scroll", visPx);
     });
   };
@@ -104,4 +108,4 @@
     $(projectInfoItems[nextIndex]).addClass('active');
   });
 
-})(jQuery); // End of use strict
+})(jQuery, window); // End of use strict

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "npm run build",
     "start:dev": "export NODE_ENV=development && gulp dev",
-    "build": "export NODE_ENV=production && gulp ",
+    "build": "rimraf ./static && export NODE_ENV=production && gulp ",
     "build:dev": "export NODE_ENV=development && gulp build-dev",
     "test": "echo \"Error: no test specified\" && exit 1",
     "deploy": "export NODE_ENV=production && gulp deploy"
@@ -30,7 +30,19 @@
     "gulp-rename": "^1.2.2",
     "gulp-uglify": "^1.5.4",
     "install": "^0.10.1",
-    "jquery": "^1.11.3"
+    "jquery": "^1.11.3",
+    "rimraf": "^2.6.1"
   },
-  "browserslist": [ "> 1%", "last 2 versions" ]
+  "devDependencies": {
+    "cheerio": "^1.0.0-rc.2",
+    "graceful-fs": "^4.1.11",
+    "gulp-util": "^3.0.8",
+    "map-stream": "^0.0.7",
+    "md5": "^2.2.1",
+    "temp-write": "^3.3.0"
+  },
+  "browserslist": [
+    "> 1%",
+    "last 2 versions"
+  ]
 }

--- a/scripts/cachebust.js
+++ b/scripts/cachebust.js
@@ -1,0 +1,69 @@
+/*
+ *
+ * https://github.com/furzeface/cachebust
+ *
+ * Copyright (c) 2014 Daniel Furze
+ * Licensed under the MIT license.]
+ *
+ */
+
+'use strict';
+
+var cheerio = require('cheerio'),
+  MD5 = require('md5'),
+  fs = require('fs');
+
+function loadAttribute(content) {
+  if (content.name.toLowerCase() === 'link') {
+    return content.attribs.href;
+  }
+
+
+  if (content.name.toLowerCase() === 'script') {
+    return content.attribs.src;
+  }
+
+  if (content.name.toLowerCase() === 'img') {
+    return content.attribs.src;
+  }
+
+  throw "No content awaited in this step of process";
+}
+
+
+exports.busted = function(fileContents, options) {
+  var self = this, $ = cheerio.load(fileContents);
+
+  self.MD5 = function(fileContents, originalAttrValue, options) {
+    var originalAttrValueWithoutCacheBusting = originalAttrValue.split("?")[0],
+        hash = MD5(fs.readFileSync(options.basePath + originalAttrValueWithoutCacheBusting).toString());
+
+    return fileContents.replace(originalAttrValue, originalAttrValueWithoutCacheBusting + '?v=' + hash);
+  };
+
+  self.timestamp = function(fileContents, originalAttrValue, options) {
+    var originalAttrValueWithoutCacheBusting = originalAttrValue.split("?")[0];
+    return fileContents.split(originalAttrValue).join(originalAttrValueWithoutCacheBusting + '?t=' + options.currentTimestamp);
+  };
+
+  options = {
+    basePath : options.basePath || "",
+    type : options.type || "MD5",
+    currentTimestamp : new Date().getTime()
+  };
+
+  var protocolRegEx = /^http(s)?/, elements = $('script[src], link[rel=stylesheet][href], img[src]');
+  var doneEntries = {};
+
+  for (var i = 0, len = elements.length; i < len; i++) {
+    var originalAttrValue = loadAttribute(elements[i]);
+
+    // Test for http(s) and don't cache bust if (assumed) served from CDN
+    if (!protocolRegEx.test(originalAttrValue) && !doneEntries[originalAttrValue]) {
+      fileContents = self[options.type](fileContents, originalAttrValue, options);
+      doneEntries[originalAttrValue] = true;
+    }
+  }
+
+  return fileContents;
+};

--- a/scripts/gulp-cache-bust.js
+++ b/scripts/gulp-cache-bust.js
@@ -1,0 +1,59 @@
+'use strict';
+
+var path = require('path');
+var fs = require('graceful-fs');
+var gutil = require('gulp-util');
+var map = require('map-stream');
+var tempWrite = require('temp-write');
+
+var cachebust = require('./cachebust');
+
+module.exports = function (options) {
+  if (!options) {
+    options = {};
+  }
+
+  return map(function (file, cb) {
+    if (file.isNull()) {
+      return cb(null, file);
+    }
+
+    if (file.isStream()) {
+      return cb(new gutil.PluginError('gulp-cachebust', 'Streaming not supported'));
+    }
+
+    if (!options.basePath) {
+      options.basePath = path.dirname(path.resolve(file.path)) + '/';
+    }
+
+    tempWrite(file.contents, path.extname(file.path))
+      .then(function (tempFile, err) {
+        if (err) {
+          return cb(new gutil.PluginError('gulp-cachebust', err));
+        }
+
+        fs.stat(tempFile, function (err, stats) {
+          if (err) {
+            return cb(new gutil.PluginError('gulp-cachebust', err));
+          }
+          options = options || {};
+
+          fs.readFile(tempFile, { encoding: 'UTF-8' }, function (err, data) {
+            if (err) {
+              return cb(new gutil.PluginError('gulp-cachebust', err));
+            }
+
+            // Call the Node module
+            var processedContents = cachebust.busted(data, options);
+
+            if (options.showLog) {
+              gutil.log('gulp-cachebust:', gutil.colors.green('✔ ') + file.relative);
+            }
+
+            file.contents = new Buffer(processedContents);
+            cb(null, file);
+          });
+        });
+      });
+  });
+};


### PR DESCRIPTION
# Description

Animations weren't working because the window object was not being passed into the jquery document load event.

Adds cache busting so that we don't fall victim to assets not updating after a deploy, due to CDN & browser caching.